### PR TITLE
Some possibility to working with native C++ objects in Duktape

### DIFF
--- a/dukglue/detail_method.h
+++ b/dukglue/detail_method.h
@@ -41,7 +41,7 @@ namespace dukglue
 
 					// read arguments and call function
 					actually_call(ctx, obj, dukglue::detail::get_stack_values<Ts...>(ctx));
-					return std::is_void<RetType>::value ? 0 : 1;
+					return std::is_same<void,RetType>::value ? 0 : 1;
 				}
 
 				// this mess is to support functions with void return values
@@ -109,7 +109,7 @@ namespace dukglue
 
 					// read arguments and call method
 					actually_call(ctx, method_holder->method, obj, dukglue::detail::get_stack_values<Ts...>(ctx));
-					return std::is_void<RetType>::value ? 0 : 1;
+					return std::is_same<void,RetType>::value ? 0 : 1;
 				}
 
 				// this mess is to support functions with void return values

--- a/dukglue/register_class.h
+++ b/dukglue/register_class.h
@@ -20,6 +20,34 @@ void dukglue_register_constructor(duk_context* ctx, const char* name)
 	duk_put_global_string(ctx, name);
 }
 
+/*
+extern "C" duk_ret_t dummy_constructor(duk_context *ctx);
+
+template<class Cls, typename... Ts>
+void dukglue_register_prototype(duk_context* ctx, const char* name)
+{
+	duk_push_c_function(ctx, dummy_constructor, 0);
+	dukglue::detail::ProtoManager::push_prototype<Cls>(ctx);
+	duk_put_prop_string(ctx, -2, "prototype");
+	duk_put_global_string(ctx, name);
+}
+*/
+
+template<class Cls>
+void dukglue_put_local_native_object(duk_context* ctx, Cls *object)
+{
+    dukglue::detail::ProtoManager::push_prototype<Cls>(ctx);
+    duk_push_pointer(ctx, object);
+    duk_put_prop_string(ctx, -2, "\xFF" "obj_ptr");
+}
+
+template<class Cls>
+void dukglue_put_global_native_object(duk_context* ctx, Cls *object, const char* name)
+{
+    dukglue_put_local_native_object(ctx,object);
+    duk_put_global_string(ctx, name);
+}
+
 template<class Base, class Derived>
 void dukglue_set_base_class(duk_context* ctx)
 {


### PR DESCRIPTION
Added functions:
**dukglue_put_global_native_object** -- puts an external C++ object to Duktape stack and registers it in global namespace
**dukglue_put_local_native_object** -- puts an external C++ object to Duktape stack
**dukglue_register_prototype** -- registers a 'class' in global namespace without possibility to create object in a  Javascript code with operator 'new'. It required for external C++ methods that returns objects.

Changes in detail_method.h
This change allows to put various external C++ objects directly on Duktape stack. In previous implementation std::is_void discarded all type modificators, so 'void' functions always returned 0 to Duktape. In other side, the std::is_void still used in 'actually_call' function, because we really don't need to parse return parameters.
For using this hack a programmer should implement a function that returns 'const void' or 'const volatile void' or something like this and put C++ object as 'local native' object to Duktape stack in there. 