### PR TITLE
Added call to register 'intercepted' method

### DIFF
--- a/include/dukglue/detail_function.h
+++ b/include/dukglue/detail_function.h
@@ -68,7 +68,7 @@ namespace dukglue
 
 					duk_pop_2(ctx);
 
-          static_assert(sizeof(RetType(*)(Ts...)) == sizeof(void*), "Function pointer and data pointer are different sizes");
+                    static_assert(sizeof(RetType(*)(Ts...)) == sizeof(void*), "Function pointer and data pointer are different sizes");
 					RetType(*funcToCall)(Ts...) = reinterpret_cast<RetType(*)(Ts...)>(fp_void);
 
 					actually_call(ctx, funcToCall, dukglue::detail::get_stack_values<Ts...>(ctx));

--- a/include/dukglue/detail_traits.h
+++ b/include/dukglue/detail_traits.h
@@ -70,10 +70,23 @@ namespace dukglue
             return pf(std::forward<Args>(std::get<Indexes>(tup))...);
         }
         
+        // function pointer
+        template<class Cls, class Ret, class... Args, class... BakedArgs, size_t... Indexes >
+        Ret apply_fp_helper_intercepted(Cls* obj, duk_context* ctx, Ret(*pf)(Cls* obj, duk_context* ctx, Args...), index_tuple< Indexes... >, std::tuple<BakedArgs...>&& tup)
+        {
+            return pf(obj, ctx, std::forward<Args>(std::get<Indexes>(tup))...);
+        }
+        
         template<class Ret, class ... Args, class ... BakedArgs>
         Ret apply_fp(Ret(*pf)(Args...), const std::tuple<BakedArgs...>&  tup)
         {
             return apply_fp_helper(pf, typename make_indexes<BakedArgs...>::type(), std::tuple<BakedArgs...>(tup));
+        }
+        
+        template<class Cls, class Ret, class ... Args, class ... BakedArgs>
+        Ret apply_fp_intercepted(Cls* obj, duk_context* ctx, Ret(*pf)(Cls* obj, duk_context* ctx, Args...), const std::tuple<BakedArgs...>&  tup)
+        {
+            return apply_fp_helper_intercepted(obj, ctx, pf, typename make_indexes<BakedArgs...>::type(), std::tuple<BakedArgs...>(tup));
         }
         
         // method pointer

--- a/include/dukglue/register_function.h
+++ b/include/dukglue/register_function.h
@@ -27,7 +27,7 @@ void dukglue_register_function(duk_context* ctx, RetType(*funcToCall)(Ts...), co
 
 	duk_push_c_function(ctx, evalFunc, sizeof...(Ts));
 
-  static_assert(sizeof(RetType(*)(Ts...)) == sizeof(void*), "Function pointer and data pointer are different sizes");
+    static_assert(sizeof(RetType(*)(Ts...)) == sizeof(void*), "Function pointer and data pointer are different sizes");
 	duk_push_pointer(ctx, reinterpret_cast<void*>(funcToCall));
 	duk_put_prop_string(ctx, -2, "\xFF" "func_ptr");
 


### PR DESCRIPTION
Often you already have some code base you would like to introduce into Javascript world. But the API you have is just not ready to be used in `dukglue_register_method`:

- It's not recommended to edit the existing code base
- Some methods return 'by value'
- Magic enums are used javascript have no idea about
- Arguments are const references

You can try to wrap your object into a wrapper that would add that dukglue-ready methods, but sometimes even that is just not possible.

Say you have this class:
```cpp
class A {
public:
    B process(const C& c, Vector2 v);
};
```
Then using simple wrapper that does not touch the original class:
```cpp
namespace AWrapper {
    B* process(A* instance, duk_context* context, C* c, Vector2* v) {
        static B b;
        b = instance->process(*c, *v);
        return &b;
    }
};
```
You can bind it:
```cpp
dukglue_register_intercepted_method<A>(ctx, "process", &AWrapper::process);
```

The bound should have two additional arguments added before the args that javascript may pass:

1. A pointer to current class instance
2. A pointer to current context

Under the hood it behaves like `dukglue_register_method` and `dukglue_register_function` combined, since both `obj_ptr` and `func_ptr` are used (honestly have no idea how it works there are way to many template magic up there).

I would appreciate a comment on how to make this PR possible.  