### PR TITLE
Add size_t and time_t types for macOS

### DIFF
--- a/include/dukglue/detail_primitive_types.h
+++ b/include/dukglue/detail_primitive_types.h
@@ -48,6 +48,8 @@ namespace dukglue {
 #ifdef __APPLE__
 		DUKGLUE_SIMPLE_VALUE_TYPE(size_t, duk_is_number, duk_get_number, duk_push_number, value)
 		DUKGLUE_SIMPLE_VALUE_TYPE(time_t, duk_is_number, duk_get_number, duk_push_number, value)
+#elif defined(__arm__)
+		DUKGLUE_SIMPLE_VALUE_TYPE(time_t, duk_is_number, duk_get_uint, duk_push_uint, value)
 #endif
 
 		// signed char and unsigned char are surprisingly *both* different from char, at least in MSVC

--- a/include/dukglue/detail_primitive_types.h
+++ b/include/dukglue/detail_primitive_types.h
@@ -45,7 +45,10 @@ namespace dukglue {
 		DUKGLUE_SIMPLE_VALUE_TYPE(int32_t, duk_is_number, duk_get_int, duk_push_int, value)
 		DUKGLUE_SIMPLE_VALUE_TYPE(int64_t, duk_is_number, duk_get_number, duk_push_number, value) // have to cast to double
 
+#ifdef __APPLE__
+		DUKGLUE_SIMPLE_VALUE_TYPE(size_t, duk_is_number, duk_get_number, duk_push_number, value)
 		DUKGLUE_SIMPLE_VALUE_TYPE(time_t, duk_is_number, duk_get_number, duk_push_number, value)
+#endif
 
 		// signed char and unsigned char are surprisingly *both* different from char, at least in MSVC
 		DUKGLUE_SIMPLE_VALUE_TYPE(char, duk_is_number, duk_get_int, duk_push_int, value)

--- a/include/dukglue/detail_primitive_types.h
+++ b/include/dukglue/detail_primitive_types.h
@@ -45,6 +45,8 @@ namespace dukglue {
 		DUKGLUE_SIMPLE_VALUE_TYPE(int32_t, duk_is_number, duk_get_int, duk_push_int, value)
 		DUKGLUE_SIMPLE_VALUE_TYPE(int64_t, duk_is_number, duk_get_number, duk_push_number, value) // have to cast to double
 
+		DUKGLUE_SIMPLE_VALUE_TYPE(time_t, duk_is_number, duk_get_number, duk_push_number, value)
+
 		// signed char and unsigned char are surprisingly *both* different from char, at least in MSVC
 		DUKGLUE_SIMPLE_VALUE_TYPE(char, duk_is_number, duk_get_int, duk_push_int, value)
 


### PR DESCRIPTION
This pull request fixes the issue #19, adding support for `time_t` and `size_t` types. I tested the changes and it works perfectly on Windows (compiled with Visual Studio 2019), Linux (both GCC and Clang), and macOS (Clang).

To be clear, those types already work on Linux and Windows, but Clang on macOS refused to compile for one reason or another, so this PR fixes this issue while maintaining compatibility with Linux and Windows.