### PR TITLE
Fixes casting signed/unsigned mismatch

### DIFF
--- a/include/dukglue/dukvalue.h
+++ b/include/dukglue/dukvalue.h
@@ -336,7 +336,7 @@ public:
 	inline duk_int_t as_int() const {
 		if (mType != NUMBER)
 			throw DukException() << "Expected number, got " << type_name();
-		return static_cast<uint32_t>(mPOD.number);
+		return static_cast<int32_t>(mPOD.number);
 	}
 
 	inline duk_uint_t as_uint() const {


### PR DESCRIPTION
We noticed that negative numbers get trimmed to zero on arm64 and trimmed the issue down to this invalid conversion.